### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/html.go
+++ b/html.go
@@ -36,7 +36,7 @@ func HtmlEncode(str string) string {
 	return html.EscapeString(str)
 }
 
-// decode string to html chars
+// HtmlDecode decodes string to html chars
 func HtmlDecode(str string) string {
 	return html.UnescapeString(str)
 }

--- a/http.go
+++ b/http.go
@@ -177,7 +177,7 @@ func FetchFiles(client *http.Client, files []RawFile, header http.Header) error 
 	return nil
 }
 
-// FetchFiles uses command `curl` to fetch files specified by the rawURL field in parallel.
+// FetchFilesCurl uses command `curl` to fetch files specified by the rawURL field in parallel.
 func FetchFilesCurl(files []RawFile, curlOptions ...string) error {
 	ch := make(chan error, len(files))
 	for i := range files {

--- a/regex.go
+++ b/regex.go
@@ -37,19 +37,19 @@ func init() {
 	regex_url = regexp.MustCompile(regex_url_pattern)
 }
 
-// validate string is an email address, if not return false
+// IsEmail validates string is an email address, if not return false
 // basically validation can match 99% cases
 func IsEmail(email string) bool {
 	return regex_email.MatchString(email)
 }
 
-// validate string is an email address, if not return false
+// IsEmailRFC validates string is an email address, if not return false
 // this validation omits RFC 2822
 func IsEmailRFC(email string) bool {
 	return regex_strict_email.MatchString(email)
 }
 
-// validate string is a url link, if not return false
+// IsUrl validates string is a url link, if not return false
 // simple validation can match 99% cases
 func IsUrl(url string) bool {
 	return regex_url.MatchString(url)

--- a/slice.go
+++ b/slice.go
@@ -44,7 +44,7 @@ func CompareSliceStr(s1, s2 []string) bool {
 	return true
 }
 
-// CompareSliceStr compares two 'string' type slices.
+// CompareSliceStrU compares two 'string' type slices.
 // It returns true if elements are the same, and ignores the order.
 func CompareSliceStrU(s1, s2 []string) bool {
 	if len(s1) != len(s2) {


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html#commentary). It’s admittedly a relatively minor fix up. Does this help you?